### PR TITLE
README update to refer to core concepts more prominently

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Once you have gone through the simple Getting Started Guide, you will then be re
   - `/experiences/` - `Note:` The experience folders in this subdirectory are for local testing purposes only. Your experience build will pull the experiences from S3 and you will reference them using the `--location` flag when creating experiences as outlined in the [ReSim Experience Documentation](https://docs.resim.ai/setup/adding-experiences/).
 - `metrics-build/` - This folder contains the metrics build that you will use to create your metrics.
 
+### URLs for the pre-baked experiences, builds, and metrics
+
+These will be added to the [Getting Started Guide](https://docs.resim.ai/setup/) in the documentation in the future, but for now, they can be found here:
+
+- Experiences: 
+  - **Maiden Flight Voyage** - `s3://resim-getting-started-demo/experiences/maiden_drone_flight/`
+  - **Drone Flight Fast** - `s3://resim-getting-started-demo/experiences/fast_drone_flight/`
+  - **Drone Flight with Warning** - `s3://resim-getting-started-demo/experiences/warning_drone_flight/`
+- **Experience Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:experience-build-v21`
+- **Metric Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:metrics-build-v24`
+
+
 ### Resources
 
 - [Overview of ReSim Core Concepts](https://docs.resim.ai/core-concepts/)


### PR DESCRIPTION
I wanted to mention two things here: 

- A design to avoid duplicating documentation into this repository, and
- Mark the Core Concepts section a bit more prominently (good recommendation by @karthikbalajikesh)

This is just some simple  README updates.