### PR TITLE
Handling experiences locally instead of through S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ These are the `--location` attributes for experiences and builds.
   - **Maiden Flight Voyage** - `experiences/maiden_drone_flight/`
   - **Drone Flight Fast** - `experiences/fast_drone_flight/`
   - **Drone Flight with Warning** - `experiences/warning_drone_flight/`
-- **Experience Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:experience-build-v21`
-- **Metric Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:metrics-build-v24`
+- **Experience Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:experience-build-v25`
+- **Metric Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:metrics-build-v25`
 
 
 ### Resources

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Once you have gone through the simple Getting Started Guide, you will then be re
 These are the `--location` attributes for experiences and builds. 
 
 - Experiences: 
-  - **Maiden Flight Voyage** - `/app/experiences/maiden_drone_flight/`
-  - **Drone Flight Fast** - `/app/experiences/fast_drone_flight/`
-  - **Drone Flight with Warning** - `/app/experiences/warning_drone_flight/`
+  - **Maiden Flight Voyage** - `experiences/maiden_drone_flight/`
+  - **Drone Flight Fast** - `experiences/fast_drone_flight/`
+  - **Drone Flight with Warning** - `experiences/warning_drone_flight/`
 - **Experience Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:experience-build-v21`
 - **Metric Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:metrics-build-v24`
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Once you have gone through the simple Getting Started Guide, you will then be re
 
 - `devcontainer/` - This folder contains the devcontainer configuration for testing things in this guide locally.
 - `experience-build/` - This folder contains the experience build that you will use to create your experiences. This `sim_run.py` script is copying over the file from your experience into the output location. Presumably your experience build will create output files based on your systems running against your experiences.
-  - `/experiences/` - `Note:` The experience folders in this subdirectory are for local testing purposes only. Your experience build will pull the experiences from S3 and you will reference them using the `--location` flag when creating experiences as outlined in the [ReSim Experience Documentation](https://docs.resim.ai/setup/adding-experiences/).
+  - `/experiences/` - These experiences are locally stored instead of S3. For your own experiences you may choose to store them in S3. 
 - `metrics-build/` - This folder contains the metrics build that you will use to create your metrics.
 
 ### URLs for the pre-baked experiences, builds, and metrics
 
-These will be added to the [Getting Started Guide](https://docs.resim.ai/setup/) in the documentation in the future, but for now, they can be found here:
+These are the `--location` attributes for experiences and builds. 
 
 - Experiences: 
-  - **Maiden Flight Voyage** - `s3://resim-getting-started-demo/experiences/maiden_drone_flight/`
-  - **Drone Flight Fast** - `s3://resim-getting-started-demo/experiences/fast_drone_flight/`
-  - **Drone Flight with Warning** - `s3://resim-getting-started-demo/experiences/warning_drone_flight/`
+  - **Maiden Flight Voyage** - `/app/experiences/maiden_drone_flight/`
+  - **Drone Flight Fast** - `/app/experiences/fast_drone_flight/`
+  - **Drone Flight with Warning** - `/app/experiences/warning_drone_flight/`
 - **Experience Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:experience-build-v21`
 - **Metric Build** - `public.ecr.aws/resim/open-builds/getting-started-demo:metrics-build-v24`
 

--- a/experience-build/Dockerfile
+++ b/experience-build/Dockerfile
@@ -7,6 +7,9 @@ RUN mkdir -p /tmp/resim/inputs/
 
 WORKDIR /app
 
+# Copy experiences folder and simulation script
+COPY experiences/ /app/experiences/
+
 COPY sim_run.py .
 
 # Default command

--- a/experience-build/experiences/README.md
+++ b/experience-build/experiences/README.md
@@ -1,3 +1,0 @@
-# Experiences in these folders are for local testing only
-
-These experiences `are for local testing purposes only`. Your experience build will pull the experiences from S3 and you will reference them using the `--location` flag when creating experiences.

--- a/experience-build/sim_run.py
+++ b/experience-build/sim_run.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shutil
 from datetime import datetime
 
 # Ensure the outputs directory exists
@@ -18,17 +19,32 @@ logging.basicConfig(
 def main():
     print("Starting simulation run...")
 
-    # Read the flight data from the input JSON file
-    input_file = "/tmp/resim/inputs/flight_log.json"
+    # Read the test_config.json file to get the experience location
+    config_path = "/tmp/resim/test_config.json"
     try:
-        with open(input_file, "r") as f:
-            flight_data = json.load(f)
-        print(f"Successfully loaded flight data from {input_file}")
+        with open(config_path, "r") as f:
+            test_config = json.load(f)
     except FileNotFoundError:
-        print(f"Error: Could not find input file at {input_file}")
+        print(f"Error: Could not find config file at {config_path}")
         return
     except json.JSONDecodeError as e:
-        print(f"Error: Invalid JSON in input file: {e}")
+        print(f"Error: Invalid JSON in config file: {e}")
+        return
+
+    experience_location = test_config["experienceLocation"]
+    print(f"Experience location: {experience_location}")
+
+    # Read the flight_log.json directly from the experience location
+    src_flight_log = os.path.join(experience_location, "flight_log.json")
+    try:
+        with open(src_flight_log, "r") as f:
+            flight_data = json.load(f)
+        print(f"Successfully loaded flight data from {src_flight_log}")
+    except FileNotFoundError:
+        print(f"Error: Could not find flight log at {src_flight_log}")
+        return
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in flight log: {e}")
         return
 
     # Write the flight data to the output log


### PR DESCRIPTION
### I had to update a few locations: 

- [x] `README.md`
- [x] Experiences folder `README.md`
- [x] `sim_run.py` to access these files locally
- [x] `Dockerfile` in the Experience build to copy over the experiences

### Verification

- [x] Tested this with ReSim? 

![image](https://github.com/user-attachments/assets/926114b7-9532-49c8-99f5-37936406a645)
