### PR TITLE
Revamping to utilize Metrics 2.0 for the example guide

### DIFF
--- a/.resim/metrics/config.yml
+++ b/.resim/metrics/config.yml
@@ -1,0 +1,45 @@
+version: 1
+
+topics: 
+  drone_speed:
+    schema:
+      speeds: float
+  nodes_crashes:
+    event: true
+    schema: 
+      name: string
+      description: string
+      status: status
+      tags: string[]
+
+metrics: 
+  Speed over time: 
+    type: test
+    description: Speed over time
+    query_string: SELECT 'speed' as group_name, timestamp, speeds FROM drone_speed
+    template_type: custom
+    template_file: custom_line.liquid
+  avg speed: 
+    type: batch
+    query_string: SELECT avg(speeds) as avg_speed FROM drone_speed
+    template_type: system
+    template: scalar
+  average drone speed over time: 
+    type: report
+    description: show how the average drone speed has changed over time.
+    query_string: |
+      SELECT 'speed' as speed, date_trunc('day', time) AS day, avg(speeds) AS avg_speed
+      FROM drone_speed
+      GROUP BY date_trunc('day', time)
+      ORDER BY day ASC
+    template_type: system
+    template: line
+
+  metrics sets:
+    drone metrics:
+      metrics:
+        - Speed over time
+        - avg speed
+    simple path planner nightly reports:
+      metrics:
+        - average drone speed over time

--- a/.resim/metrics/config.yml
+++ b/.resim/metrics/config.yml
@@ -1,45 +1,52 @@
 version: 1
 
-topics: 
+topics:
   drone_speed:
     schema:
-      speeds: float
-  nodes_crashes:
-    event: true
-    schema: 
-      name: string
-      description: string
-      status: status
-      tags: string[]
+      speed: float
+  
+  drone_position:
+    schema:
+      x: float
+      y: float
+      z: float
+  
+  drone_state:
+    schema:
+      state: string
+  
+  drone_status:
+    schema:
+      status: string
 
-metrics: 
-  Speed over time: 
+metrics:
+  Speed over time:
     type: test
     description: Speed over time
-    query_string: SELECT 'speed' as group_name, timestamp, speeds FROM drone_speed
+    query_string: SELECT 'speed' as group_name, timestamp, speed FROM drone_speed
     template_type: custom
     template_file: custom_line.liquid
-  avg speed: 
+  avg speed:
     type: batch
-    query_string: SELECT avg(speeds) as avg_speed FROM drone_speed
+    query_string: SELECT avg(speed) as avg_speed FROM drone_speed
     template_type: system
     template: scalar
-  average drone speed over time: 
+  average drone speed over time:
     type: report
     description: show how the average drone speed has changed over time.
     query_string: |
-      SELECT 'speed' as speed, date_trunc('day', time) AS day, avg(speeds) AS avg_speed
+      SELECT 'speed' as speed, date_trunc('day', time) AS day, avg(speed) AS avg_speed
       FROM drone_speed
       GROUP BY date_trunc('day', time)
-      ORDER BY day ASC
+      ORDER BY day ASC;
     template_type: system
     template: line
 
-  metrics sets:
-    drone metrics:
-      metrics:
-        - Speed over time
-        - avg speed
-    simple path planner nightly reports:
-      metrics:
-        - average drone speed over time
+metrics sets:
+  drone metrics:
+    metrics:
+      - Speed over time
+      - avg speed
+  simple path planner nightly reports:
+    metrics:
+      - average drone speed over time

--- a/experience-build/Dockerfile
+++ b/experience-build/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="matthew@resim.ai"
 # Create ReSim input directory structure
 RUN mkdir -p /tmp/resim/inputs/
 
+# Copy over metrics config to container and make directory
+
 WORKDIR /app
 
 # Copy experiences folder and simulation script

--- a/experience-build/sim_run.py
+++ b/experience-build/sim_run.py
@@ -1,19 +1,10 @@
 import json
-import logging
 import os
-import shutil
 from datetime import datetime
+from resim.sdk.metrics.emissions import Emitter
 
 # Ensure the outputs directory exists
 os.makedirs("/tmp/resim/outputs/", exist_ok=True)
-
-# Set up logging
-logging.basicConfig(
-    filename="/tmp/resim/outputs/processed_flight_log.json",
-    level=logging.INFO,
-    format="%(message)s",  # We'll just log the raw JSON data
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
 
 
 def main():
@@ -47,11 +38,66 @@ def main():
         print(f"Error: Invalid JSON in flight log: {e}")
         return
 
-    # Write the flight data to the output log
-    with open("/tmp/resim/outputs/processed_flight_log.json", "w") as f:
-        json.dump(flight_data, f, indent=2)
+    # Validate flight data structure
+    if "samples" not in flight_data:
+        print("Error: Flight log must contain 'samples' key")
+        return
 
-    print("Completed writing flight data. Exiting.")
+    samples = flight_data.get("samples", [])
+    if not samples:
+        print("Warning: Flight log contains no samples")
+        return
+
+    # Parse timestamps and convert to nanoseconds (relative to first timestamp)
+    timestamps = []
+    first_timestamp_ns = None
+
+    for sample in samples:
+        if "timestamp" not in sample:
+            print("Error: Sample missing 'timestamp' field")
+            return
+        
+        # Parse ISO 8601 timestamp
+        dt = datetime.fromisoformat(sample["timestamp"])
+        timestamp_ns = int(dt.timestamp() * 1e9)
+        
+        if first_timestamp_ns is None:
+            first_timestamp_ns = timestamp_ns
+        
+        # Calculate relative timestamp
+        relative_timestamp = timestamp_ns - first_timestamp_ns
+        timestamps.append(relative_timestamp)
+
+    # Extract data arrays for each topic
+    speeds = [sample.get("speed", 0.0) for sample in samples]
+    positions_x = [sample.get("position", {}).get("x", 0.0) for sample in samples]
+    positions_y = [sample.get("position", {}).get("y", 0.0) for sample in samples]
+    positions_z = [sample.get("position", {}).get("z", 0.0) for sample in samples]
+    states = [sample.get("state", "") for sample in samples]
+    statuses = [sample.get("status", "") for sample in samples]
+
+    # Emit data using Metrics 2.0 Emitter
+    config_path = ".resim/metrics/config.yml"
+    output_path = "/tmp/resim/outputs/emissions.resim.jsonl"
+    
+    with Emitter(config_path=config_path, output_path=output_path) as emitter:
+        # Emit speed data
+        emitter.emit_series("drone_speed", {"speed": speeds}, timestamps=timestamps)
+        
+        # Emit position data
+        emitter.emit_series(
+            "drone_position",
+            {"x": positions_x, "y": positions_y, "z": positions_z},
+            timestamps=timestamps
+        )
+        
+        # Emit state data
+        emitter.emit_series("drone_state", {"state": states}, timestamps=timestamps)
+        
+        # Emit status data
+        emitter.emit_series("drone_status", {"status": statuses}, timestamps=timestamps)
+
+    print(f"Completed emitting flight data to {output_path}. Exiting.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Opening the pull request early, still a work in progress. 

### Things I need to do:

- [x] Create .resim/metrics/config.yml with initial topics (you can start with no metrics) and sync it:
- [ ] Run: resim metrics sync --project "my-project"
- [ ] Update your system test/build to emit JSONL using the Metrics SDK, writing to /tmp/resim/outputs/emissions.resim.jsonl.
- [ ] Run a small batch (1–2 tests) using your build.
- [ ] In the dashboard, verify emissions were ingested and inspect early charts to confirm schemas/fields look right.
- [ ] Develop metrics queries and select templates (start with system templates like line, bar, scalar).
- [ ] Add your metrics and a metrics set to .resim/metrics/config.yml.
- [ ] Sync the config again: resim metrics sync --project "my-project".
- [ ] Run another batch selecting your new metrics set (the metrics2 pool label will be added for you automatically):
./resim batches create --metrics-set "blah blah" ...